### PR TITLE
Update install.sh

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -2,6 +2,6 @@
 # This file will be automatically sourced at the installation of your plugin
 # Use only if you need to perform changes on the user system such as installing software
 sudo apt-get update && apt-get install vlc nohup
-sudo sudo apt-get remove -y youtube-dl
+sudo apt-get remove -y youtube-dl
 sudo wget https://yt-dl.org/latest/youtube-dl -O /usr/local/bin/youtube-dl
 sudo chmod a+rx /usr/local/bin/youtube-dl

--- a/install.sh
+++ b/install.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 # This file will be automatically sourced at the installation of your plugin
 # Use only if you need to perform changes on the user system such as installing software
-apt-get update
-apt-get install vlc nohup
+sudo apt-get update && apt-get install vlc nohup
+sudo sudo apt-get remove -y youtube-dl
+sudo wget https://yt-dl.org/latest/youtube-dl -O /usr/local/bin/youtube-dl
+sudo chmod a+rx /usr/local/bin/youtube-dl


### PR DESCRIPTION
It appeared that stock version of youtube-dl installed by default on Raspbian, a python tool used by mpv player to decode videos, is really outdated. There is a bug with this tool while using it with nohup, bug which has been corrected from a very long time by the team in charge of youtube-dl. The solution is, according to the authors of the script, to remove the stock version and reinstall it from scratch. 
In order to make this jarvis plugin usable again, this update seems necessary. At the moment, the plugin is not able to read any music, precisely because of this outdated tool.